### PR TITLE
Fix structlog.get_level_from_name AttributeError in logging setup

### DIFF
--- a/src/financial_agent/utils/logging.py
+++ b/src/financial_agent/utils/logging.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
+
 import structlog
 
 
 def setup_logging(level: str = "INFO") -> None:
     """Configure structured logging for the application."""
+    numeric_level = getattr(logging, level.upper(), logging.INFO)
     structlog.configure(
         processors=[
             structlog.contextvars.merge_contextvars,
@@ -16,7 +19,7 @@ def setup_logging(level: str = "INFO") -> None:
             structlog.processors.TimeStamper(fmt="iso"),
             structlog.processors.JSONRenderer(),
         ],
-        wrapper_class=structlog.make_filtering_bound_logger(structlog.get_level_from_name(level)),
+        wrapper_class=structlog.make_filtering_bound_logger(numeric_level),
         context_class=dict,
         logger_factory=structlog.PrintLoggerFactory(),
         cache_logger_on_first_use=True,


### PR DESCRIPTION
structlog no longer exposes get_level_from_name. Use stdlib logging.getattr to convert the level string to a numeric value instead.

https://claude.ai/code/session_01YFZGn9hgwhbfYJZGRV75ZN

## Summary

<!-- Brief description of changes -->

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Strategy/trading logic change
- [ ] Configuration change
- [ ] CI/CD change
- [ ] Documentation
- [ ] Refactor (no functional change)

## Trading Impact

<!-- If this changes trading behavior, describe the impact -->

- [ ] This PR changes trading logic or strategy
- [ ] This PR changes position sizing or risk parameters
- [ ] This PR changes broker integration
- [ ] This PR has NO trading impact

## Risk Assessment

<!-- For trading-related changes -->

- **Backtested:** Yes / No / N/A
- **Paper-traded:** Yes / No / N/A
- **Risk level:** Low / Medium / High

## Testing

- [ ] Unit tests pass (`pytest`)
- [ ] Lint passes (`ruff check`)
- [ ] Type check passes (`mypy`)
- [ ] Tested with paper trading account

## Checklist

- [ ] No API keys or secrets in code
- [ ] Configuration uses environment variables
- [ ] Changes are documented in code comments where non-obvious
- [ ] Dry-run mode still works correctly
