### PR TITLE
Fix mypy strict mode errors blocking CI

### DIFF
--- a/src/financial_agent/analysis/ai_analyzer.py
+++ b/src/financial_agent/analysis/ai_analyzer.py
@@ -88,7 +88,7 @@ class AIAnalyzer:
             messages=[{"role": "user", "content": prompt}],
         )
 
-        raw_text = response.content[0].text
+        raw_text = response.content[0].text  # type: ignore[union-attr]
         signals, analysis_summary = self._parse_response(raw_text)
 
         log.info(

--- a/src/financial_agent/broker/alpaca_client.py
+++ b/src/financial_agent/broker/alpaca_client.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import structlog
 from alpaca.data.historical import CryptoHistoricalDataClient, StockHistoricalDataClient
@@ -37,7 +37,7 @@ class AlpacaBroker:
 
     def get_account_info(self) -> dict[str, Any]:
         """Get account balance and status."""
-        account = self._trading.get_account()
+        account: Any = self._trading.get_account()
         return {
             "equity": float(account.equity),
             "cash": float(account.cash),
@@ -49,7 +49,7 @@ class AlpacaBroker:
 
     def get_positions(self) -> list[Position]:
         """Get all current positions."""
-        raw_positions = self._trading.get_all_positions()
+        raw_positions: Any = self._trading.get_all_positions()
         positions = []
         for p in raw_positions:
             asset_cls = (
@@ -96,8 +96,8 @@ class AlpacaBroker:
             timeframe=timeframe,
             start=datetime.now() - timedelta(days=days),
         )
-        bars = self._data.get_stock_bars(request)
-        return bars.df
+        bars: Any = self._data.get_stock_bars(request)
+        return cast("pd.DataFrame", bars.df)
 
     def get_crypto_historical_bars(
         self,
@@ -111,8 +111,8 @@ class AlpacaBroker:
             timeframe=timeframe,
             start=datetime.now() - timedelta(days=days),
         )
-        bars = self._crypto_data.get_crypto_bars(request)
-        return bars.df
+        bars: Any = self._crypto_data.get_crypto_bars(request)
+        return cast("pd.DataFrame", bars.df)
 
     def submit_order(self, order: TradeOrder, dry_run: bool = True) -> dict[str, Any]:
         """Submit a trade order. Returns order details."""
@@ -136,7 +136,7 @@ class AlpacaBroker:
             type=OrderType.MARKET,
             time_in_force=tif,
         )
-        result = self._trading.submit_order(request)
+        result: Any = self._trading.submit_order(request)
         log.info("order_executed", order_id=result.id, status=result.status)
         return {
             "status": str(result.status),
@@ -148,5 +148,5 @@ class AlpacaBroker:
 
     def is_market_open(self) -> bool:
         """Check if the market is currently open."""
-        clock = self._trading.get_clock()
-        return clock.is_open
+        clock: Any = self._trading.get_clock()
+        return cast("bool", clock.is_open)

--- a/src/financial_agent/config.py
+++ b/src/financial_agent/config.py
@@ -102,8 +102,8 @@ class TradingConfig(BaseSettings):
 class AppConfig(BaseSettings):
     """Top-level application configuration."""
 
-    broker: BrokerConfig = Field(default_factory=BrokerConfig)
-    ai: AIConfig = Field(default_factory=AIConfig)
+    broker: BrokerConfig = Field(default_factory=BrokerConfig)  # type: ignore[arg-type]
+    ai: AIConfig = Field(default_factory=AIConfig)  # type: ignore[arg-type]
     trading: TradingConfig = Field(default_factory=TradingConfig)
 
     log_level: str = Field(

--- a/src/financial_agent/main.py
+++ b/src/financial_agent/main.py
@@ -128,7 +128,7 @@ def _normalize_crypto_symbol(symbol: str) -> str:
     return symbol
 
 
-def _write_github_output(summary: dict) -> None:
+def _write_github_output(summary: dict[str, object]) -> None:
     """Write summary to GITHUB_OUTPUT for use in subsequent workflow steps."""
     import os
 

--- a/src/financial_agent/review/reviewer.py
+++ b/src/financial_agent/review/reviewer.py
@@ -80,7 +80,7 @@ class PortfolioReviewer:
             messages=[{"role": "user", "content": prompt}],
         )
 
-        raw_text = response.content[0].text
+        raw_text = response.content[0].text  # type: ignore[union-attr]
         result = self._parse_review(raw_text)
 
         log.info(

--- a/src/financial_agent/review/watchlist_reviewer.py
+++ b/src/financial_agent/review/watchlist_reviewer.py
@@ -91,7 +91,7 @@ class WatchlistReviewer:
             messages=[{"role": "user", "content": prompt}],
         )
 
-        raw_text = response.content[0].text
+        raw_text = response.content[0].text  # type: ignore[union-attr]
         result = self._parse_response(raw_text)
 
         log.info(

--- a/src/financial_agent/strategy/technical.py
+++ b/src/financial_agent/strategy/technical.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import ta
+import ta  # type: ignore[import-untyped]
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/src/financial_agent/utils/logging.py
+++ b/src/financial_agent/utils/logging.py
@@ -9,7 +9,7 @@ import structlog
 
 def setup_logging(level: str = "INFO") -> None:
     """Configure structured logging for the application."""
-    numeric_level = getattr(logging, level.upper(), logging.INFO)
+    numeric_level: int = getattr(logging, level.upper(), logging.INFO)
     structlog.configure(
         processors=[
             structlog.contextvars.merge_contextvars,


### PR DESCRIPTION
## Summary

- Resolves all **39 mypy strict mode errors** caused by imprecise third-party SDK type annotations
- `mypy src/` now reports **0 errors** (was 39)
- All 71 tests pass, ruff lint + format clean

## Approach

| File | Fix |
|------|-----|
| `broker/alpaca_client.py` | Cast alpaca SDK returns (`get_account`, `get_all_positions`, `get_stock_bars`, `get_crypto_bars`, `submit_order`, `get_clock`) to `Any`, then `cast()` final return values to declared types |
| `analysis/ai_analyzer.py` | `# type: ignore[union-attr]` for anthropic `TextBlock \| ToolUseBlock` on `.text` |
| `review/reviewer.py` | Same anthropic union fix |
| `review/watchlist_reviewer.py` | Same anthropic union fix |
| `config.py` | `# type: ignore[arg-type]` for Pydantic `Field(default_factory=...)` with `BaseSettings` subclasses |
| `strategy/technical.py` | `# type: ignore[import-untyped]` for `ta` library (no stubs) |
| `utils/logging.py` | Annotate `numeric_level: int` for `getattr` return |
| `main.py` | Add type parameters to bare `dict` annotation |

Closes #5

## Test plan

- [x] `mypy src/` — 0 errors (was 39)
- [x] `ruff check src/ tests/` — all checks passed
- [x] `ruff format --check src/ tests/` — all formatted
- [x] `pytest -v` — 71 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)