### PR TITLE
Fix crash when selling fractional crypto positions

### DIFF
--- a/src/financial_agent/broker/alpaca_client.py
+++ b/src/financial_agent/broker/alpaca_client.py
@@ -165,7 +165,24 @@ class AlpacaBroker:
                 time_in_force=tif,
             )
 
-        result: Any = self._trading.submit_order(request)
+        try:
+            result: Any = self._trading.submit_order(request)
+        except Exception:
+            log.error(
+                "order_submission_failed",
+                symbol=order.symbol,
+                side=order.side,
+                qty=order.qty,
+                exc_info=True,
+            )
+            return {
+                "status": "failed",
+                "symbol": order.symbol,
+                "qty": str(order.qty),
+                "side": order.side,
+                "type": order.order_type.value,
+            }
+
         log.info("order_executed", order_id=result.id, status=result.status)
         return {
             "status": str(result.status),

--- a/src/financial_agent/main.py
+++ b/src/financial_agent/main.py
@@ -165,6 +165,11 @@ def main() -> None:  # noqa: PLR0912, PLR0915
         result = broker.submit_order(order, dry_run=config.trading.dry_run)
         results.append(result)
 
+        # Only record successful trades
+        if result.get("status") == "failed":
+            log.warning("order_failed_skipping_record", symbol=order.symbol)
+            continue
+
         # Record trade and update thesis (Issues #27, #20)
         _record_trade(order, result, thesis_store, perf_tracker, signals)
 

--- a/src/financial_agent/strategy/engine.py
+++ b/src/financial_agent/strategy/engine.py
@@ -273,6 +273,16 @@ class StrategyEngine:
             # Sell quantity scaled by confidence
             sell_qty = round(position.qty * signal.confidence, 2)
 
+        # Clamp to actual position size — rounding can exceed it for small crypto quantities
+        if sell_qty > position.qty:
+            log.warning(
+                "sell_qty_clamped",
+                symbol=signal.symbol,
+                computed=sell_qty,
+                available=position.qty,
+            )
+            sell_qty = position.qty
+
         if sell_qty <= 0:
             return None
 

--- a/tests/unit/test_broker.py
+++ b/tests/unit/test_broker.py
@@ -60,6 +60,20 @@ class TestSubmitOrderTimeInForce:
         assert result["status"] == "dry_run"
         broker._trading.submit_order.assert_not_called()
 
+    def test_submission_error_returns_failed_status(self):
+        broker = _make_broker()
+        broker._trading.submit_order.side_effect = Exception("insufficient balance")
+        order = TradeOrder(
+            symbol="BTC/USD",
+            side="sell",
+            qty=0.01,
+            reason="test",
+            asset_class=AssetClass.CRYPTO,
+        )
+        result = broker.submit_order(order, dry_run=False)
+        assert result["status"] == "failed"
+        assert result["symbol"] == "BTC/USD"
+
 
 class TestGetPositionsAssetClass:
     def test_crypto_position_detected(self):

--- a/tests/unit/test_strategy_engine.py
+++ b/tests/unit/test_strategy_engine.py
@@ -201,3 +201,33 @@ class TestStrategyEngine:
         assert len(orders) == 1
         assert orders[0].asset_class == AssetClass.CRYPTO
         assert orders[0].side == "sell"
+
+    def test_sell_qty_clamped_for_fractional_crypto(self):
+        """Rounding can produce sell_qty > position.qty for small crypto holdings."""
+        engine = StrategyEngine(_make_config())
+        # 0.00945 * 0.95 = 0.008978, rounds to 0.01 which exceeds 0.00945
+        portfolio = _make_portfolio(
+            positions=[
+                Position(
+                    symbol="BTC/USD",
+                    qty=0.00945,
+                    avg_entry_price=50000.0,
+                    current_price=55000.0,
+                    market_value=519.75,
+                    unrealized_pl=47.25,
+                    unrealized_pl_pct=0.1,
+                    asset_class=AssetClass.CRYPTO,
+                )
+            ]
+        )
+        signal = TradeSignal(
+            symbol="BTC/USD",
+            signal=SignalType.SELL,
+            confidence=0.95,
+            reason="Exit crypto",
+            asset_class=AssetClass.CRYPTO,
+        )
+        orders = engine.generate_orders([signal], portfolio)
+        assert len(orders) == 1
+        assert orders[0].qty <= 0.00945
+        assert orders[0].qty == 0.00945  # Clamped to actual position


### PR DESCRIPTION
## Summary

- **Root cause:** `round(0.00945 * 0.95, 2) = 0.01` — rounding up exceeded the actual 0.00945 BTC position, causing an Alpaca "insufficient balance" error that crashed the entire trading run ([failed run](https://github.com/mikejamescalvert/Financial-Agent/actions/runs/22323871559))
- **Fix 1 — `strategy/engine.py`:** Clamp `sell_qty` to `position.qty` when rounding produces a value larger than the actual holding
- **Fix 2 — `broker/alpaca_client.py`:** Wrap `submit_order` in try/except so API errors return `{"status": "failed"}` instead of crashing
- **Fix 3 — `main.py`:** Skip trade recording for failed orders and continue processing remaining orders

| File | Change |
|------|--------|
| `src/financial_agent/strategy/engine.py` | Clamp sell qty to position size after rounding |
| `src/financial_agent/broker/alpaca_client.py` | Catch order submission exceptions gracefully |
| `src/financial_agent/main.py` | Skip failed orders, continue executing remaining |
| `tests/unit/test_strategy_engine.py` | Test: fractional crypto qty clamping (reproduces exact bug) |
| `tests/unit/test_broker.py` | Test: submission error returns failed status |

## Test plan

- [x] New test `test_sell_qty_clamped_for_fractional_crypto` reproduces the exact 0.00945 * 0.95 scenario
- [x] New test `test_submission_error_returns_failed_status` verifies broker error handling
- [x] All 261 tests pass
- [x] Lint clean (`ruff check`)
- [x] Type check clean (`mypy --strict`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)