### PR TITLE
Migrate FMP from deprecated v3 to stable API

### DIFF
--- a/src/financial_agent/data/earnings.py
+++ b/src/financial_agent/data/earnings.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 log = structlog.get_logger()
 
-_FMP_BASE = "https://financialmodelingprep.com/api/v3"
+_FMP_BASE = "https://financialmodelingprep.com/stable"
 
 
 class EarningsProvider:
@@ -46,7 +46,7 @@ class EarningsProvider:
         from_date = today.isoformat()
         to_date = (today + timedelta(days=14)).isoformat()
 
-        url = f"{_FMP_BASE}/earning_calendar?from={from_date}&to={to_date}&apikey={self._api_key}"
+        url = f"{_FMP_BASE}/earnings-calendar?from={from_date}&to={to_date}&apikey={self._api_key}"
         req = urllib.request.Request(url)  # noqa: S310
         req.add_header("User-Agent", "FinancialAgent/1.0")
 

--- a/src/financial_agent/data/fundamentals.py
+++ b/src/financial_agent/data/fundamentals.py
@@ -1,4 +1,4 @@
-"""Fundamentals data provider using Financial Modeling Prep (FMP) free API."""
+"""Fundamentals data provider using Financial Modeling Prep (FMP) stable API."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 log = structlog.get_logger()
 
-_FMP_BASE = "https://financialmodelingprep.com/api/v3"
+_FMP_BASE = "https://financialmodelingprep.com/stable"
 
 
 class FundamentalsProvider:
@@ -40,7 +40,7 @@ class FundamentalsProvider:
                 time.sleep(0.5)
 
             try:
-                data = self._fetch_profile(symbol)
+                data = self._fetch_fundamentals(symbol)
                 if data is not None:
                     results[symbol] = data
             except Exception:
@@ -49,11 +49,9 @@ class FundamentalsProvider:
         log.info("fundamentals_fetched", count=len(results), total=len(symbols))
         return results
 
-    def _fetch_profile(self, symbol: str) -> FundamentalData | None:
-        """Fetch a single symbol's profile from FMP and parse into model."""
-        from financial_agent.data.models import FundamentalData
-
-        url = f"{_FMP_BASE}/profile/{symbol}?apikey={self._api_key}"
+    def _fetch_json(self, endpoint: str, params: str = "") -> list[dict[str, object]]:
+        """Fetch a JSON array from an FMP stable endpoint."""
+        url = f"{_FMP_BASE}/{endpoint}?{params}&apikey={self._api_key}"
         req = urllib.request.Request(url)  # noqa: S310
         req.add_header("User-Agent", "FinancialAgent/1.0")
 
@@ -61,20 +59,40 @@ class FundamentalsProvider:
             body = json.loads(resp.read().decode())
 
         if not body or not isinstance(body, list) or len(body) == 0:
+            return []
+        return body  # type: ignore[no-any-return]
+
+    def _fetch_fundamentals(self, symbol: str) -> FundamentalData | None:
+        """Fetch a symbol's fundamentals from FMP stable endpoints.
+
+        Combines data from three endpoints:
+        - /stable/profile for market cap
+        - /stable/ratios for financial ratios (P/E, margins, etc.)
+        - /stable/financial-growth for revenue growth
+        """
+        from financial_agent.data.models import FundamentalData
+
+        profile = self._fetch_json("profile", f"symbol={symbol}")
+        if not profile:
             log.warning("fundamentals_empty_response", symbol=symbol)
             return None
 
-        profile = body[0]
+        ratios = self._fetch_json("ratios", f"symbol={symbol}&period=annual&limit=1")
+        growth = self._fetch_json("financial-growth", f"symbol={symbol}&period=annual&limit=1")
+
+        p = profile[0]
+        r = ratios[0] if ratios else {}
+        g = growth[0] if growth else {}
 
         return FundamentalData(
-            eps_ttm=_safe_float(profile.get("eps")),
-            pe_ratio=_safe_float(profile.get("pe")),
-            revenue_growth=_safe_float(profile.get("revenueGrowth")),
-            profit_margin=_safe_float(profile.get("netIncomeMargin")),
-            debt_to_equity=_safe_float(profile.get("debtToEquity")),
-            free_cash_flow=_safe_float(profile.get("freeCashFlow")),
-            price_to_book=_safe_float(profile.get("priceToBook")),
-            market_cap=_safe_float(profile.get("mktCap")),
+            eps_ttm=_safe_float(r.get("netIncomePerShare")),
+            pe_ratio=_safe_float(r.get("priceToEarningsRatio")),
+            revenue_growth=_safe_float(g.get("revenueGrowth")),
+            profit_margin=_safe_float(r.get("netProfitMargin")),
+            debt_to_equity=_safe_float(r.get("debtToEquityRatio")),
+            free_cash_flow=_safe_float(r.get("freeCashFlowPerShare")),
+            price_to_book=_safe_float(r.get("priceToBookRatio")),
+            market_cap=_safe_float(p.get("marketCap")),
         )
 
 


### PR DESCRIPTION
## Summary
- FMP deprecated `/api/v3/profile` and `/api/v3/earning_calendar` endpoints after August 2025, causing 100% failure on fundamentals and earnings data
- Migrated `fundamentals.py` to use `/stable/profile`, `/stable/ratios`, and `/stable/financial-growth` endpoints with updated field mappings
- Migrated `earnings.py` to use `/stable/earnings-calendar` endpoint

## Test plan
- [x] All 261 tests pass
- [x] Lint, format, and mypy clean
- [ ] Dry run after merge to verify live FMP data flows through

🤖 Generated with [Claude Code](https://claude.com/claude-code)