### PR TITLE
Fix duplicate limit orders, FMP parsing, and screener crash

### DIFF
--- a/src/financial_agent/broker/alpaca_client.py
+++ b/src/financial_agent/broker/alpaca_client.py
@@ -10,8 +10,8 @@ from alpaca.data.historical import CryptoHistoricalDataClient, StockHistoricalDa
 from alpaca.data.requests import CryptoBarsRequest, StockBarsRequest
 from alpaca.data.timeframe import TimeFrame
 from alpaca.trading.client import TradingClient
-from alpaca.trading.enums import OrderSide, OrderType, TimeInForce
-from alpaca.trading.requests import LimitOrderRequest, MarketOrderRequest
+from alpaca.trading.enums import OrderSide, OrderType, QueryOrderStatus, TimeInForce
+from alpaca.trading.requests import GetOrdersRequest, LimitOrderRequest, MarketOrderRequest
 
 from financial_agent.portfolio.models import (
     AssetClass,
@@ -121,6 +121,54 @@ class AlpacaBroker:
         )
         bars: Any = self._crypto_data.get_crypto_bars(request)
         return cast("pd.DataFrame", bars.df)
+
+    def get_pending_orders(self, symbol: str | None = None) -> list[dict[str, Any]]:
+        """Get open (pending/partially filled) orders, optionally filtered by symbol."""
+        try:
+            request = GetOrdersRequest(status=QueryOrderStatus.OPEN)
+            if symbol:
+                request = GetOrdersRequest(status=QueryOrderStatus.OPEN, symbols=[symbol])
+            raw_orders: Any = self._trading.get_orders(request)
+            results = []
+            for o in raw_orders:
+                results.append(
+                    {
+                        "id": str(o.id),
+                        "symbol": o.symbol,
+                        "side": str(o.side),
+                        "qty": str(o.qty),
+                        "type": str(o.type),
+                        "status": str(o.status),
+                    }
+                )
+            return results
+        except Exception:
+            log.warning("get_pending_orders_failed", symbol=symbol, exc_info=True)
+            return []
+
+    def cancel_pending_orders(self, symbol: str) -> int:
+        """Cancel all open orders for a given symbol. Returns count cancelled."""
+        pending = self.get_pending_orders(symbol)
+        cancelled = 0
+        for order in pending:
+            try:
+                self._trading.cancel_order_by_id(order["id"])
+                cancelled += 1
+                log.info(
+                    "pending_order_cancelled",
+                    symbol=symbol,
+                    order_id=order["id"],
+                    side=order["side"],
+                    qty=order["qty"],
+                )
+            except Exception:
+                log.warning(
+                    "cancel_order_failed",
+                    symbol=symbol,
+                    order_id=order["id"],
+                    exc_info=True,
+                )
+        return cancelled
 
     def submit_order(self, order: TradeOrder, dry_run: bool = True) -> dict[str, Any]:
         """Submit a trade order. Supports market and limit orders."""

--- a/src/financial_agent/data/earnings.py
+++ b/src/financial_agent/data/earnings.py
@@ -53,6 +53,9 @@ class EarningsProvider:
         with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
             body = json.loads(resp.read().decode())
 
+        # Handle dict response (FMP stable API may return a single object)
+        if isinstance(body, dict):
+            body = [body]
         if not isinstance(body, list):
             log.warning("earnings_unexpected_response", body_type=type(body).__name__)
             return []

--- a/src/financial_agent/data/fundamentals.py
+++ b/src/financial_agent/data/fundamentals.py
@@ -50,7 +50,7 @@ class FundamentalsProvider:
         return results
 
     def _fetch_json(self, endpoint: str, params: str = "") -> list[dict[str, object]]:
-        """Fetch a JSON array from an FMP stable endpoint."""
+        """Fetch JSON from an FMP stable endpoint. Handles both dict and list responses."""
         url = f"{_FMP_BASE}/{endpoint}?{params}&apikey={self._api_key}"
         req = urllib.request.Request(url)  # noqa: S310
         req.add_header("User-Agent", "FinancialAgent/1.0")
@@ -58,9 +58,14 @@ class FundamentalsProvider:
         with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
             body = json.loads(resp.read().decode())
 
-        if not body or not isinstance(body, list) or len(body) == 0:
+        if not body:
             return []
-        return body  # type: ignore[no-any-return]
+        # /stable/profile returns a single dict; other endpoints return a list
+        if isinstance(body, dict):
+            return [body]
+        if not isinstance(body, list):
+            return []
+        return body
 
     def _fetch_fundamentals(self, symbol: str) -> FundamentalData | None:
         """Fetch a symbol's fundamentals from FMP stable endpoints.

--- a/src/financial_agent/main.py
+++ b/src/financial_agent/main.py
@@ -159,7 +159,14 @@ def main() -> None:  # noqa: PLR0912, PLR0915
     orders = engine.generate_orders(all_signals, portfolio, technicals, enrichment)
     log.info("orders_generated", count=len(orders))
 
-    # Step 8: Execute orders
+    # Step 8: Cancel pending orders for symbols we're about to trade, then execute
+    if not config.trading.dry_run:
+        symbols_to_trade = {o.symbol for o in orders}
+        for sym in symbols_to_trade:
+            cancelled = broker.cancel_pending_orders(sym)
+            if cancelled:
+                log.info("stale_orders_cancelled", symbol=sym, count=cancelled)
+
     results = []
     for order in orders:
         result = broker.submit_order(order, dry_run=config.trading.dry_run)

--- a/src/financial_agent/screener_main.py
+++ b/src/financial_agent/screener_main.py
@@ -58,6 +58,11 @@ def main() -> None:
 
     log.info("screening_universe", total=len(stock_universe))
 
+    if not stock_universe:
+        log.info("screener_skip", reason="empty stock universe")
+        _write_github_output({"alerts": 0})
+        return
+
     # Fetch technical data for full universe
     try:
         bars = broker.get_historical_bars(stock_universe, days=config.trading.historical_days)

--- a/tests/unit/test_broker.py
+++ b/tests/unit/test_broker.py
@@ -113,6 +113,73 @@ class TestGetPositionsAssetClass:
         assert positions[0].asset_class == AssetClass.US_EQUITY
 
 
+class TestPendingOrderManagement:
+    def test_get_pending_orders_returns_open_orders(self):
+        broker = _make_broker()
+        mock_order = MagicMock()
+        mock_order.id = "order-123"
+        mock_order.symbol = "AAPL"
+        mock_order.side = "buy"
+        mock_order.qty = "5"
+        mock_order.type = "limit"
+        mock_order.status = "new"
+        broker._trading.get_orders.return_value = [mock_order]
+
+        orders = broker.get_pending_orders("AAPL")
+        assert len(orders) == 1
+        assert orders[0]["id"] == "order-123"
+        assert orders[0]["symbol"] == "AAPL"
+
+    def test_get_pending_orders_handles_exception(self):
+        broker = _make_broker()
+        broker._trading.get_orders.side_effect = Exception("API error")
+        orders = broker.get_pending_orders("AAPL")
+        assert orders == []
+
+    def test_cancel_pending_orders_cancels_all(self):
+        broker = _make_broker()
+        mock_order1 = MagicMock()
+        mock_order1.id = "order-1"
+        mock_order1.symbol = "XOM"
+        mock_order1.side = "buy"
+        mock_order1.qty = "0.12"
+        mock_order1.type = "limit"
+        mock_order1.status = "new"
+        mock_order2 = MagicMock()
+        mock_order2.id = "order-2"
+        mock_order2.symbol = "XOM"
+        mock_order2.side = "buy"
+        mock_order2.qty = "0.11"
+        mock_order2.type = "limit"
+        mock_order2.status = "new"
+        broker._trading.get_orders.return_value = [mock_order1, mock_order2]
+
+        cancelled = broker.cancel_pending_orders("XOM")
+        assert cancelled == 2
+        assert broker._trading.cancel_order_by_id.call_count == 2
+
+    def test_cancel_pending_orders_handles_partial_failure(self):
+        broker = _make_broker()
+        mock_order = MagicMock()
+        mock_order.id = "order-1"
+        mock_order.symbol = "AAPL"
+        mock_order.side = "buy"
+        mock_order.qty = "1"
+        mock_order.type = "limit"
+        mock_order.status = "new"
+        broker._trading.get_orders.return_value = [mock_order]
+        broker._trading.cancel_order_by_id.side_effect = Exception("already filled")
+
+        cancelled = broker.cancel_pending_orders("AAPL")
+        assert cancelled == 0
+
+    def test_cancel_pending_orders_with_no_pending(self):
+        broker = _make_broker()
+        broker._trading.get_orders.return_value = []
+        cancelled = broker.cancel_pending_orders("AAPL")
+        assert cancelled == 0
+
+
 class TestNormalizeCryptoSymbol:
     def test_already_normalized(self):
         assert _normalize_crypto_symbol("BTC/USD") == "BTC/USD"


### PR DESCRIPTION
## Summary

- **Cancel stale pending orders before submitting new ones** — the agent was submitting limit orders every 30 minutes without canceling prior ones. On down days, multiple fills for the same symbol drained cash unexpectedly (today: 7 XOM limit buys all filled, depleting cash from $347 to $12).
- **Fix FMP stable API response parsing** — `/stable/profile` returns a dict, not an array. All 10 fundamental fetches were failing silently since the v3→stable migration.
- **Fix screener crash on empty stock universe** — `TRADING_STOCK_UNIVERSE` env var defaults to empty string in the workflow, causing an Alpaca API error.

## Changes

| File | Change |
|------|--------|
| `broker/alpaca_client.py` | Add `get_pending_orders()` and `cancel_pending_orders()` methods |
| `main.py` | Cancel pending orders for traded symbols before submitting new ones |
| `data/fundamentals.py` | Handle both dict and list responses from FMP stable API |
| `data/earnings.py` | Handle dict response from FMP stable earnings endpoint |
| `screener_main.py` | Guard against empty stock universe |
| `tests/unit/test_broker.py` | 5 new tests for pending order management |

## Test plan

- [x] All 266 tests pass (5 new)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy` strict clean
- [ ] CI pipeline (lint + tests + security scan)
- [ ] Verify next trading run shows `stale_orders_cancelled` log entries
- [ ] Verify `fundamentals_fetched` shows count > 0 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)