### PR TITLE
Add PDT protection to prevent day trade violations

### DIFF
--- a/src/financial_agent/broker/alpaca_client.py
+++ b/src/financial_agent/broker/alpaca_client.py
@@ -122,6 +122,33 @@ class AlpacaBroker:
         bars: Any = self._crypto_data.get_crypto_bars(request)
         return cast("pd.DataFrame", bars.df)
 
+    def get_todays_filled_sides(self) -> dict[str, set[str]]:
+        """Get symbols and sides that have filled orders today.
+
+        Returns a dict like {"AAPL": {"buy"}, "JPM": {"buy", "sell"}}.
+        Used to detect potential day trades before submitting new orders.
+        """
+        try:
+            today_start = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+            request = GetOrdersRequest(
+                status=QueryOrderStatus.CLOSED,
+                after=today_start,
+                limit=200,
+            )
+            raw_orders: Any = self._trading.get_orders(request)
+            result: dict[str, set[str]] = {}
+            for o in raw_orders:
+                if str(o.status) == "filled":
+                    sym = o.symbol
+                    side = str(o.side)
+                    if sym not in result:
+                        result[sym] = set()
+                    result[sym].add(side)
+            return result
+        except Exception:
+            log.warning("get_todays_fills_failed", exc_info=True)
+            return {}
+
     def get_pending_orders(self, symbol: str | None = None) -> list[dict[str, Any]]:
         """Get open (pending/partially filled) orders, optionally filtered by symbol."""
         try:

--- a/src/financial_agent/main.py
+++ b/src/financial_agent/main.py
@@ -159,13 +159,37 @@ def main() -> None:  # noqa: PLR0912, PLR0915
     orders = engine.generate_orders(all_signals, portfolio, technicals, enrichment)
     log.info("orders_generated", count=len(orders))
 
-    # Step 8: Cancel pending orders for symbols we're about to trade, then execute
+    # Step 8: Cancel pending orders and filter for PDT protection, then execute
     if not config.trading.dry_run:
         symbols_to_trade = {o.symbol for o in orders}
         for sym in symbols_to_trade:
             cancelled = broker.cancel_pending_orders(sym)
             if cancelled:
                 log.info("stale_orders_cancelled", symbol=sym, count=cancelled)
+
+        # PDT protection: block orders that would create a day trade
+        # (buying and selling the same symbol on the same day)
+        todays_fills = broker.get_todays_filled_sides()
+        _opposite = {"buy": "sell", "sell": "buy"}
+        safe_orders: list[TradeOrder] = []
+        for order in orders:
+            filled_sides = todays_fills.get(order.symbol, set())
+            if _opposite.get(order.side, "") in filled_sides:
+                log.warning(
+                    "order_blocked_pdt",
+                    symbol=order.symbol,
+                    side=order.side,
+                    reason="opposite side already filled today",
+                )
+            else:
+                safe_orders.append(order)
+        if len(safe_orders) < len(orders):
+            log.info(
+                "pdt_filter_applied",
+                original=len(orders),
+                allowed=len(safe_orders),
+            )
+        orders = safe_orders
 
     results = []
     for order in orders:

--- a/tests/unit/test_broker.py
+++ b/tests/unit/test_broker.py
@@ -180,6 +180,51 @@ class TestPendingOrderManagement:
         assert cancelled == 0
 
 
+class TestTodaysFilledSides:
+    def test_returns_filled_orders_grouped_by_symbol(self):
+        broker = _make_broker()
+        buy_order = MagicMock()
+        buy_order.status = "filled"
+        buy_order.symbol = "AAPL"
+        buy_order.side = "buy"
+        sell_order = MagicMock()
+        sell_order.status = "filled"
+        sell_order.symbol = "AAPL"
+        sell_order.side = "sell"
+        other_order = MagicMock()
+        other_order.status = "filled"
+        other_order.symbol = "JPM"
+        other_order.side = "buy"
+        broker._trading.get_orders.return_value = [buy_order, sell_order, other_order]
+
+        result = broker.get_todays_filled_sides()
+        assert result["AAPL"] == {"buy", "sell"}
+        assert result["JPM"] == {"buy"}
+
+    def test_skips_non_filled_orders(self):
+        broker = _make_broker()
+        cancelled_order = MagicMock()
+        cancelled_order.status = "canceled"
+        cancelled_order.symbol = "AAPL"
+        cancelled_order.side = "buy"
+        broker._trading.get_orders.return_value = [cancelled_order]
+
+        result = broker.get_todays_filled_sides()
+        assert result == {}
+
+    def test_returns_empty_on_exception(self):
+        broker = _make_broker()
+        broker._trading.get_orders.side_effect = Exception("API error")
+        result = broker.get_todays_filled_sides()
+        assert result == {}
+
+    def test_returns_empty_when_no_orders(self):
+        broker = _make_broker()
+        broker._trading.get_orders.return_value = []
+        result = broker.get_todays_filled_sides()
+        assert result == {}
+
+
 class TestNormalizeCryptoSymbol:
     def test_already_normalized(self):
         assert _normalize_crypto_symbol("BTC/USD") == "BTC/USD"


### PR DESCRIPTION
## Summary
- Adds `get_todays_filled_sides()` to AlpacaBroker that queries today's filled orders and returns which sides (buy/sell) have filled per symbol
- Adds a pre-submission filter in main.py Step 8 that blocks orders whose opposite side already filled today, preventing Pattern Day Trading violations
- Accounts under $25k (ours is ~$992) are subject to PDT rules — Alpaca rejects trades that would create a day trade (buy+sell same symbol same day)

## Changes
| File | Change |
|------|--------|
| `broker/alpaca_client.py` | New `get_todays_filled_sides()` method |
| `main.py` | PDT filter in Step 8 before order submission |
| `tests/unit/test_broker.py` | 4 new tests for filled sides detection |

## Test plan
- [x] 270 tests pass (4 new)
- [x] ruff check clean
- [x] ruff format clean
- [x] mypy strict clean
- [ ] Verify on next trading run: orders blocked with `order_blocked_pdt` log when opposite side already filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)