### PR TITLE
Fix agent passivity, issue spam, API failures, and weekend waste

### DIFF
--- a/.github/workflows/portfolio-review.yml
+++ b/.github/workflows/portfolio-review.yml
@@ -2,8 +2,8 @@ name: Portfolio Review
 
 on:
   schedule:
-    # Run daily at 9 PM UTC (after US market close at 4 PM ET)
-    - cron: '0 21 * * *'
+    # Run weekdays at 9 PM UTC (after US market close at 4 PM ET)
+    - cron: '0 21 * * 1-5'
 
   workflow_dispatch:  # Allow manual trigger
 

--- a/.github/workflows/trading-agent.yml
+++ b/.github/workflows/trading-agent.yml
@@ -2,9 +2,10 @@ name: Trading Agent
 
 on:
   schedule:
-    # Every 30 minutes, 24/7 — crypto trades around the clock,
-    # stocks are filtered to market hours in the agent logic
-    - cron: '*/30 * * * *'
+    # Every 30 minutes on weekdays (stocks + crypto)
+    - cron: '*/30 * * * 1-5'
+    # Every 4 hours on weekends (crypto only — saves API credits)
+    - cron: '0 */4 * * 0,6'
 
   workflow_dispatch:
     inputs:

--- a/src/financial_agent/analysis/ai_analyzer.py
+++ b/src/financial_agent/analysis/ai_analyzer.py
@@ -36,14 +36,22 @@ growth, high debt, poor margins) unless there's a clear technical catalyst.
 8. **Support/resistance**: Factor in proximity to key levels for entry and exit timing.
 
 ## Risk Rules
-- Be conservative with confidence scores. Only use >0.8 for very strong, multi-factor signals.
+- Use the full confidence range: >0.7 for solid multi-factor signals, >0.85 for exceptional setups.
 - Always provide a clear reason for each signal.
 - Consider the overall portfolio balance, sector exposure, and correlation.
-- If indicators are mixed or unclear, recommend HOLD.
-- Never recommend more than 3 BUY signals at once to avoid over-trading.
+- If indicators are genuinely mixed, recommend HOLD — but do NOT default to HOLD out of caution \
+when there is a reasonable signal. A cash-heavy portfolio is itself a risk (opportunity cost).
+- Never recommend more than 5 BUY signals at once to avoid over-trading.
 - Consider the current strategy mode when making recommendations.
-- If portfolio drawdown is elevated, bias toward defensive positioning.
+- If portfolio drawdown is elevated (>10%), bias toward defensive positioning.
 - If a position's original trade thesis is invalidated, recommend SELL regardless of P/L.
+
+## Capital Deployment Rules
+- High cash allocation (>30%) should be treated as a problem to solve, not a safe position.
+- When cash is excessive, actively look for deployment opportunities rather than defaulting to HOLD.
+- Micro positions (<3% of portfolio) that are losing should be exited promptly — they drag returns \
+without meaningful portfolio impact.
+- Crypto trades 24/7 and can be bought even when stock markets are closed — use this advantage.
 
 ## Crypto-specific rules
 - Crypto symbols may contain "/" (e.g., BTC/USD) or appear as concatenated (e.g., BTCUSD). \
@@ -102,6 +110,7 @@ class AIAnalyzer:
         theses_prompt: str = "",
         equity_prompt: str = "",
         performance_prompt: str = "",
+        review_issues_prompt: str = "",
     ) -> tuple[list[TradeSignal], str]:
         """Send portfolio + technical data + enrichment to Claude and parse signals.
 
@@ -114,6 +123,7 @@ class AIAnalyzer:
             theses_prompt,
             equity_prompt,
             performance_prompt,
+            review_issues_prompt,
         )
 
         log.info("ai_analysis_started", model=self._model, symbols=list(technicals.keys()))
@@ -146,6 +156,7 @@ class AIAnalyzer:
         theses_prompt: str,
         equity_prompt: str,
         performance_prompt: str,
+        review_issues_prompt: str = "",
     ) -> str:
         """Build the analysis prompt with all available data."""
         sections: list[str] = []
@@ -208,6 +219,14 @@ class AIAnalyzer:
         # Performance metrics (Issue #20)
         if performance_prompt:
             sections.append(f"## Performance Metrics\n{performance_prompt}")
+
+        # Portfolio review suggestions (feed review agent insights into trading decisions)
+        if review_issues_prompt:
+            sections.append(
+                f"## Recent Portfolio Review Suggestions\n"
+                f"The portfolio review agent identified these issues. Factor them into your "
+                f"analysis and consider acting on high-priority items:\n{review_issues_prompt}"
+            )
 
         # Technical indicators
         rounded_technicals = {

--- a/src/financial_agent/data/crypto_market.py
+++ b/src/financial_agent/data/crypto_market.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import urllib.request
+from datetime import UTC, datetime
+from pathlib import Path
 
 import structlog
 
@@ -12,7 +14,11 @@ from financial_agent.data.models import CryptoMarketContext
 log = structlog.get_logger()
 
 _COINGECKO_GLOBAL = "https://api.coingecko.com/api/v3/global"
-_FEAR_GREED_URL = "https://api.alternative.me/fapi/v1/fear-and-greed-index/"
+# Primary and fallback Fear & Greed endpoints
+_FEAR_GREED_URLS = [
+    "https://api.alternative.me/fng/?limit=1",
+    "https://api.alternative.me/fapi/v1/fear-and-greed-index/",
+]
 
 _FEAR_GREED_LABELS: dict[str, str] = {
     "Extreme Fear": "extreme_fear",
@@ -21,6 +27,9 @@ _FEAR_GREED_LABELS: dict[str, str] = {
     "Greed": "greed",
     "Extreme Greed": "extreme_greed",
 }
+
+_CACHE_FILE = ".data/crypto_market_cache.json"
+_CACHE_MAX_AGE_HOURS = 4
 
 
 class CryptoMarketProvider:
@@ -33,11 +42,19 @@ class CryptoMarketProvider:
         """Fetch crypto market context.
 
         Returns a CryptoMarketContext with None values on any failure.
+        Falls back to cached data when APIs are unavailable.
         """
         try:
-            return self._build_context()
+            ctx = self._build_context()
+            # Cache if we got meaningful data
+            if ctx.btc_dominance is not None or ctx.fear_greed_index is not None:
+                self._save_cache(ctx)
+            return ctx
         except Exception:
             log.warning("crypto_market_fetch_error", exc_info=True)
+            cached = self._load_cache()
+            if cached:
+                return cached
             return CryptoMarketContext()
 
     def _build_context(self) -> CryptoMarketContext:
@@ -99,27 +116,73 @@ class CryptoMarketProvider:
     def _fetch_fear_greed(self) -> tuple[int | None, str]:
         """Fetch the crypto Fear & Greed Index.
 
-        Returns (index_value, label).
+        Tries multiple endpoint URLs as fallback. Returns (index_value, label).
         """
+        for url in _FEAR_GREED_URLS:
+            try:
+                data = _fetch_json(url)
+
+                data_list = data.get("data", [])
+                if not isinstance(data_list, list) or not data_list:
+                    continue
+
+                entry = data_list[0]
+                if not isinstance(entry, dict):
+                    continue
+
+                value = int(entry.get("value", 0))
+                raw_label = str(entry.get("value_classification", "Neutral"))
+                label = _FEAR_GREED_LABELS.get(raw_label, "neutral")
+
+                return value, label
+            except Exception:
+                log.debug("fear_greed_endpoint_failed", url=url, exc_info=True)
+
+        log.warning("fear_greed_fetch_error", reason="all endpoints failed")
+        return None, "neutral"
+
+    def _save_cache(self, ctx: CryptoMarketContext) -> None:
+        """Persist crypto market data to disk for offline fallback."""
         try:
-            data = _fetch_json(_FEAR_GREED_URL)
-
-            data_list = data.get("data", [])
-            if not isinstance(data_list, list) or not data_list:
-                return None, "neutral"
-
-            entry = data_list[0]
-            if not isinstance(entry, dict):
-                return None, "neutral"
-
-            value = int(entry.get("value", 0))
-            raw_label = str(entry.get("value_classification", "Neutral"))
-            label = _FEAR_GREED_LABELS.get(raw_label, "neutral")
-
-            return value, label
+            cache_path = Path(_CACHE_FILE)
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            cache_data = {
+                "timestamp": datetime.now(tz=UTC).isoformat(),
+                "btc_dominance": ctx.btc_dominance,
+                "fear_greed_index": ctx.fear_greed_index,
+                "fear_greed_label": ctx.fear_greed_label,
+                "btc_trend": ctx.btc_trend,
+                "total_market_cap": ctx.total_market_cap,
+            }
+            cache_path.write_text(json.dumps(cache_data))
         except Exception:
-            log.warning("fear_greed_fetch_error", exc_info=True)
-            return None, "neutral"
+            log.debug("crypto_cache_save_failed", exc_info=True)
+
+    def _load_cache(self) -> CryptoMarketContext | None:
+        """Load cached crypto market data if fresh enough."""
+        try:
+            cache_path = Path(_CACHE_FILE)
+            if not cache_path.exists():
+                return None
+
+            raw = json.loads(cache_path.read_text())
+            cached_time = datetime.fromisoformat(raw["timestamp"])
+            age_hours = (datetime.now(tz=UTC) - cached_time).total_seconds() / 3600
+
+            if age_hours > _CACHE_MAX_AGE_HOURS:
+                return None
+
+            log.info("crypto_market_loaded_from_cache", age_hours=round(age_hours, 1))
+            return CryptoMarketContext(
+                btc_dominance=raw.get("btc_dominance"),
+                fear_greed_index=raw.get("fear_greed_index"),
+                fear_greed_label=raw.get("fear_greed_label", "neutral"),
+                btc_trend=raw.get("btc_trend", "neutral"),
+                total_market_cap=raw.get("total_market_cap"),
+            )
+        except Exception:
+            log.debug("crypto_cache_load_failed", exc_info=True)
+            return None
 
 
 def _fetch_json(url: str) -> dict[str, object]:

--- a/src/financial_agent/data/earnings.py
+++ b/src/financial_agent/data/earnings.py
@@ -1,10 +1,11 @@
-"""Earnings calendar provider using Financial Modeling Prep (FMP) free API."""
+"""Earnings calendar provider using Financial Modeling Prep (FMP) stable API."""
 
 from __future__ import annotations
 
 import json
 import urllib.request
-from datetime import date, timedelta
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import structlog
@@ -15,6 +16,8 @@ if TYPE_CHECKING:
 log = structlog.get_logger()
 
 _FMP_BASE = "https://financialmodelingprep.com/stable"
+_CACHE_FILE = ".data/earnings_cache.json"
+_CACHE_MAX_AGE_HOURS = 12
 
 
 class EarningsProvider:
@@ -27,15 +30,83 @@ class EarningsProvider:
         """Fetch upcoming earnings events for the given symbols.
 
         Returns events within the next 14 days, sorted by days until earnings.
+        Falls back to cached data when the API is unavailable.
         """
         if not self._api_key:
             log.info("earnings_skip", reason="no FMP API key configured")
             return []
 
         try:
-            return self._fetch_calendar(symbols)
+            result = self._fetch_calendar(symbols)
+            if result is not None:
+                self._save_cache(result, symbols)
+            return result if result is not None else self._load_cache(symbols)
         except Exception:
             log.warning("earnings_fetch_error", exc_info=True)
+            return self._load_cache(symbols)
+
+    def _save_cache(self, events: list[EarningsEvent], symbols: list[str]) -> None:
+        """Persist earnings data to disk for offline fallback."""
+        try:
+            cache_path = Path(_CACHE_FILE)
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            cache_data = {
+                "timestamp": datetime.now(tz=UTC).isoformat(),
+                "symbols": symbols,
+                "events": [
+                    {
+                        "symbol": e.symbol,
+                        "earnings_date": e.earnings_date.isoformat(),
+                        "days_until_earnings": e.days_until_earnings,
+                        "eps_estimate": e.eps_estimate,
+                    }
+                    for e in events
+                ],
+            }
+            cache_path.write_text(json.dumps(cache_data))
+        except Exception:
+            log.debug("earnings_cache_save_failed", exc_info=True)
+
+    def _load_cache(self, symbols: list[str]) -> list[EarningsEvent]:
+        """Load cached earnings if fresh enough."""
+        from financial_agent.data.models import EarningsEvent
+
+        try:
+            cache_path = Path(_CACHE_FILE)
+            if not cache_path.exists():
+                return []
+
+            raw = json.loads(cache_path.read_text())
+            cached_time = datetime.fromisoformat(raw["timestamp"])
+            age_hours = (datetime.now(tz=UTC) - cached_time).total_seconds() / 3600
+
+            if age_hours > _CACHE_MAX_AGE_HOURS:
+                return []
+
+            symbol_set = {s.upper() for s in symbols}
+            today = date.today()
+            events: list[EarningsEvent] = []
+            for e in raw.get("events", []):
+                if e["symbol"].upper() not in symbol_set:
+                    continue
+                earnings_date = date.fromisoformat(e["earnings_date"])
+                days_until = (earnings_date - today).days
+                if days_until < 0:
+                    continue
+                events.append(
+                    EarningsEvent(
+                        symbol=e["symbol"],
+                        earnings_date=earnings_date,
+                        days_until_earnings=days_until,
+                        eps_estimate=e.get("eps_estimate"),
+                    )
+                )
+            events.sort(key=lambda ev: ev.days_until_earnings)
+            if events:
+                log.info("earnings_loaded_from_cache", count=len(events))
+            return events
+        except Exception:
+            log.debug("earnings_cache_load_failed", exc_info=True)
             return []
 
     def _fetch_calendar(self, symbols: list[str]) -> list[EarningsEvent]:

--- a/src/financial_agent/data/fundamentals.py
+++ b/src/financial_agent/data/fundamentals.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import time
 import urllib.request
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import structlog
@@ -15,6 +17,8 @@ if TYPE_CHECKING:
 log = structlog.get_logger()
 
 _FMP_BASE = "https://financialmodelingprep.com/stable"
+_CACHE_FILE = ".data/fundamentals_cache.json"
+_CACHE_MAX_AGE_HOURS = 12
 
 
 class FundamentalsProvider:
@@ -27,7 +31,8 @@ class FundamentalsProvider:
         """Fetch fundamental data for a list of symbols.
 
         Returns a dict mapping symbol -> FundamentalData. Symbols that fail
-        to fetch are silently skipped (logged as warnings).
+        to fetch are silently skipped (logged as warnings). Falls back to
+        cached data when fresh fetches fail.
         """
         if not self._api_key:
             log.info("fundamentals_skip", reason="no FMP API key configured")
@@ -46,8 +51,76 @@ class FundamentalsProvider:
             except Exception:
                 log.warning("fundamentals_fetch_error", symbol=symbol, exc_info=True)
 
-        log.info("fundamentals_fetched", count=len(results), total=len(symbols))
+        # If we got results, cache them for offline use
+        if results:
+            self._save_cache(results)
+            log.info("fundamentals_fetched", count=len(results), total=len(symbols))
+            return results
+
+        # No fresh data — try the cache
+        cached = self._load_cache(symbols)
+        if cached:
+            log.info(
+                "fundamentals_fetched_from_cache",
+                count=len(cached),
+                total=len(symbols),
+            )
+            return cached
+
+        log.info("fundamentals_fetched", count=0, total=len(symbols))
         return results
+
+    def _save_cache(self, results: dict[str, FundamentalData]) -> None:
+        """Persist fundamentals to disk for offline fallback."""
+        try:
+            cache_path = Path(_CACHE_FILE)
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            cache_data = {
+                "timestamp": datetime.now(tz=UTC).isoformat(),
+                "data": {
+                    sym: {
+                        "eps_ttm": fd.eps_ttm,
+                        "pe_ratio": fd.pe_ratio,
+                        "revenue_growth": fd.revenue_growth,
+                        "profit_margin": fd.profit_margin,
+                        "debt_to_equity": fd.debt_to_equity,
+                        "free_cash_flow": fd.free_cash_flow,
+                        "price_to_book": fd.price_to_book,
+                        "market_cap": fd.market_cap,
+                    }
+                    for sym, fd in results.items()
+                },
+            }
+            cache_path.write_text(json.dumps(cache_data))
+        except Exception:
+            log.debug("fundamentals_cache_save_failed", exc_info=True)
+
+    def _load_cache(self, symbols: list[str]) -> dict[str, FundamentalData]:
+        """Load cached fundamentals if fresh enough."""
+        from financial_agent.data.models import FundamentalData
+
+        try:
+            cache_path = Path(_CACHE_FILE)
+            if not cache_path.exists():
+                return {}
+
+            raw = json.loads(cache_path.read_text())
+            cached_time = datetime.fromisoformat(raw["timestamp"])
+            age_hours = (datetime.now(tz=UTC) - cached_time).total_seconds() / 3600
+
+            if age_hours > _CACHE_MAX_AGE_HOURS:
+                log.debug("fundamentals_cache_expired", age_hours=round(age_hours, 1))
+                return {}
+
+            results: dict[str, FundamentalData] = {}
+            symbol_set = {s.upper() for s in symbols}
+            for sym, vals in raw.get("data", {}).items():
+                if sym.upper() in symbol_set:
+                    results[sym] = FundamentalData(**vals)
+            return results
+        except Exception:
+            log.debug("fundamentals_cache_load_failed", exc_info=True)
+            return {}
 
     def _fetch_json(self, endpoint: str, params: str = "") -> list[dict[str, object]]:
         """Fetch JSON from an FMP stable endpoint. Handles both dict and list responses."""

--- a/src/financial_agent/main.py
+++ b/src/financial_agent/main.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 from datetime import UTC, datetime
 
@@ -142,6 +143,7 @@ def main() -> None:  # noqa: PLR0912, PLR0915
     theses_prompt = thesis_store.format_for_prompt()
     equity_prompt = equity_tracker.format_for_prompt()
     perf_prompt = perf_tracker.format_for_prompt(equity_tracker.daily_returns(30))
+    review_prompt = _fetch_review_issues(log)
 
     signals, analysis_summary = ai.analyze(
         portfolio,
@@ -150,6 +152,7 @@ def main() -> None:  # noqa: PLR0912, PLR0915
         theses_prompt=theses_prompt,
         equity_prompt=equity_prompt,
         performance_prompt=perf_prompt,
+        review_issues_prompt=review_prompt,
     )
 
     # Merge trailing stop signals with AI signals
@@ -350,6 +353,61 @@ def _record_trade(
         existing = thesis_store.get_thesis(order.symbol)
         if existing:
             thesis_store.close_thesis(order.symbol, reason=order.reason)
+
+
+def _fetch_review_issues(log: object) -> str:
+    """Fetch recent high-priority portfolio review issues from GitHub.
+
+    Returns a formatted string of recent review suggestions, or empty string on failure.
+    """
+    _log = structlog.get_logger()
+    try:
+        result = subprocess.run(  # noqa: S603
+            [  # noqa: S607
+                "gh",
+                "issue",
+                "list",
+                "--label",
+                "portfolio-review,high-priority",
+                "--state",
+                "open",
+                "--limit",
+                "5",
+                "--json",
+                "title,labels,body",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            return ""
+
+        issues = json.loads(result.stdout)
+        if not issues:
+            return ""
+
+        lines: list[str] = []
+        for issue in issues:
+            title = issue.get("title", "")
+            # Extract just the first paragraph of the body for brevity
+            body = issue.get("body", "")
+            summary = body.split("\n---")[0].split("\n\n")[1] if "\n\n" in body else ""
+            priority_labels = [
+                lbl.get("name", "") if isinstance(lbl, dict) else str(lbl)
+                for lbl in issue.get("labels", [])
+                if isinstance(lbl, dict) and lbl.get("name", "").endswith("-priority")
+            ]
+            priority = priority_labels[0] if priority_labels else "medium-priority"
+            lines.append(f"- **[{priority}]** {title}")
+            if summary:
+                lines.append(f"  {summary[:200]}")
+
+        prompt = "\n".join(lines)
+        _log.info("review_issues_loaded", count=len(issues))
+        return prompt
+    except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError):
+        return ""
 
 
 def _normalize_crypto_symbol(symbol: str) -> str:

--- a/src/financial_agent/review_main.py
+++ b/src/financial_agent/review_main.py
@@ -22,6 +22,121 @@ from financial_agent.strategy import TechnicalAnalyzer
 from financial_agent.utils.logging import setup_logging
 
 
+def _run_gh_command(cmd: list[str], timeout: int = 30) -> tuple[bool, str]:
+    """Run a gh CLI command and return (success, stdout)."""
+    try:
+        result = subprocess.run(  # noqa: S603, S607
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return result.returncode == 0, result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return False, ""
+
+
+def _get_open_review_categories() -> set[str]:
+    """Get the set of categories that already have open portfolio-review issues.
+
+    Returns category labels (e.g. 'risk', 'strategy', 'config') that have at least
+    one open issue, so we can skip creating duplicates.
+    """
+    log = structlog.get_logger()
+    success, output = _run_gh_command(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--label",
+            "portfolio-review",
+            "--state",
+            "open",
+            "--limit",
+            "30",
+            "--json",
+            "labels",
+        ],
+    )
+    if not success or not output:
+        return set()
+
+    try:
+        issues = json.loads(output)
+    except json.JSONDecodeError:
+        return set()
+
+    # Extract category labels from existing open issues
+    category_labels = {"risk", "performance", "strategy", "config", "watchlist"}
+    existing: set[str] = set()
+    for issue in issues:
+        for label in issue.get("labels", []):
+            name = label.get("name", "") if isinstance(label, dict) else str(label)
+            if name in category_labels:
+                existing.add(name)
+
+    log.info("existing_review_categories", categories=sorted(existing), open_issues=len(issues))
+    return existing
+
+
+def _close_stale_review_issues() -> int:
+    """Close portfolio-review issues older than 5 days to prevent buildup."""
+    log = structlog.get_logger()
+    success, output = _run_gh_command(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--label",
+            "portfolio-review",
+            "--state",
+            "open",
+            "--limit",
+            "100",
+            "--json",
+            "number,createdAt",
+        ],
+    )
+    if not success or not output:
+        return 0
+
+    try:
+        issues = json.loads(output)
+    except json.JSONDecodeError:
+        return 0
+
+    from datetime import UTC, datetime, timedelta
+
+    cutoff = datetime.now(tz=UTC) - timedelta(days=5)
+    closed = 0
+    for issue in issues:
+        created = issue.get("createdAt", "")
+        try:
+            created_dt = datetime.fromisoformat(created.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            continue
+        if created_dt < cutoff:
+            num = issue["number"]
+            ok, _ = _run_gh_command(
+                [
+                    "gh",
+                    "issue",
+                    "close",
+                    str(num),
+                    "--reason",
+                    "not planned",
+                    "--comment",
+                    "Auto-closed: superseded by newer portfolio review.",
+                ],
+            )
+            if ok:
+                closed += 1
+
+    if closed:
+        log.info("stale_issues_closed", count=closed)
+    return closed
+
+
 def _create_github_issue(title: str, body: str, labels: list[str]) -> bool:
     """Create a GitHub issue using the gh CLI.
 
@@ -33,26 +148,12 @@ def _create_github_issue(title: str, body: str, labels: list[str]) -> bool:
     for label in labels:
         cmd.extend(["--label", label])
 
-    try:
-        result = subprocess.run(  # noqa: S603, S607
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        if result.returncode == 0:
-            log.info("github_issue_created", title=title, url=result.stdout.strip())
-            return True
-        else:
-            log.error(
-                "github_issue_failed",
-                title=title,
-                stderr=result.stderr.strip(),
-                returncode=result.returncode,
-            )
-            return False
-    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
-        log.error("github_issue_error", title=title, error=str(e))
+    success, output = _run_gh_command(cmd)
+    if success:
+        log.info("github_issue_created", title=title, url=output)
+        return True
+    else:
+        log.error("github_issue_failed", title=title)
         return False
 
 
@@ -149,6 +250,12 @@ def main() -> None:
         _write_github_output({"grade": grade, "summary": summary, "issues_created": 0})
         return
 
+    # Close stale issues before creating new ones
+    _close_stale_review_issues()
+
+    # Check which categories already have open issues to avoid duplicates
+    existing_categories = _get_open_review_categories()
+
     # Ensure labels exist
     all_labels: set[str] = {"portfolio-review"}
     for s in suggestions:
@@ -162,11 +269,18 @@ def main() -> None:
     _ensure_labels_exist(all_labels)
 
     issues_created = 0
+    skipped = 0
     for suggestion in suggestions:
         title = suggestion.get("title", "Portfolio improvement suggestion")
         priority = suggestion.get("priority", "medium")
         category = suggestion.get("category", "")
         body_text = suggestion.get("body", "")
+
+        # Skip if an open issue already covers this category
+        if category and category in existing_categories:
+            log.info("issue_skipped_duplicate", title=title, category=category)
+            skipped += 1
+            continue
 
         # Build issue body with context
         issue_body = f"""## Portfolio Review — Grade: {grade}
@@ -201,8 +315,16 @@ _This issue was automatically created by the portfolio review agent._
 
         if _create_github_issue(title, issue_body, labels):
             issues_created += 1
+            # Track newly created category to avoid duplicates within same run
+            if category:
+                existing_categories.add(category)
 
-    log.info("review_agent_complete", grade=grade, issues_created=issues_created)
+    log.info(
+        "review_agent_complete",
+        grade=grade,
+        issues_created=issues_created,
+        skipped=skipped,
+    )
 
     _write_github_output(
         {


### PR DESCRIPTION
## Summary

Comprehensive fix for 6 production issues identified from analyzing the last few days of runs:

- **Weekend API waste**: Trading agent was running every 30 min on weekends burning ~$1-2/day in Anthropic credits for zero-value "market closed, hold" results. Now runs every 4 hours on weekends (crypto only) and every 30 min on weekdays.
- **Issue spam**: Portfolio review was creating 5 duplicate issues every night (50 total accumulated). Added category-based deduplication and auto-close of stale issues >5 days old. Bulk-closed all 50 existing stale issues.
- **FMP API failures off-hours**: Fundamentals, earnings, and crypto market data all failed during off-market hours, leaving the AI blind. Added file-based caching that persists the last successful fetch and falls back to it when API calls fail.
- **Fear & Greed broken**: The alternative.me endpoint was failing. Added fallback URL (`/fng/?limit=1`) and retry logic across multiple endpoints.
- **Agent paralysis**: The AI was stuck in a permanent "defensive positioning" loop with 56.7% cash. Tuned the system prompt to treat high cash as a risk, raised max buy signals from 3→5, lowered confidence thresholds, and added capital deployment rules.
- **Review→Trading disconnect**: Portfolio review agent created good suggestions (deploy cash, exit micro positions, add crypto) but the trading agent never saw them. Now fetches high-priority review issues from GitHub and includes them in the AI prompt.

### Files changed

| File | Change |
|------|--------|
| `trading-agent.yml` | Split cron: weekday every 30 min, weekend every 4 hours |
| `portfolio-review.yml` | Weekdays only (was daily) |
| `review_main.py` | Issue dedup by category + auto-close stale issues |
| `fundamentals.py` | File-based cache with 12h TTL |
| `earnings.py` | File-based cache with 12h TTL |
| `crypto_market.py` | Cache + Fear & Greed URL fallback |
| `ai_analyzer.py` | Less passive prompt + review issues in context |
| `main.py` | Fetch review issues from GitHub for AI prompt |

## Test plan

- [x] All 270 tests passing
- [x] Lint clean (ruff check + ruff format)
- [x] Type check clean (mypy strict)
- [ ] CI pipeline (lint + tests + security)
- [ ] Verify next weekday trading run picks up review issues
- [ ] Verify next portfolio review creates fewer, non-duplicate issues
- [ ] Monitor API cache hit rate in off-hours runs

### Config change needed after merge
Consider lowering `TRADING_MIN_CASH_RESERVE_PCT` from `0.10` to `0.05` in GitHub Variables to let the agent deploy more of the idle 56.7% cash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)