### PR TITLE
Fix invalid Claude model ID breaking all agent runs

### DIFF
--- a/.github/workflows/portfolio-review.yml
+++ b/.github/workflows/portfolio-review.yml
@@ -57,7 +57,7 @@ jobs:
 
           # Configuration (reuses trading variables)
           ALPACA_BASE_URL: ${{ vars.ALPACA_BASE_URL || 'https://paper-api.alpaca.markets' }}
-          ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6-20250620' }}
+          ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6-20250514' }}
           TRADING_MAX_POSITION_PCT: ${{ vars.TRADING_MAX_POSITION_PCT || '0.10' }}
           TRADING_MAX_DAILY_TRADES: ${{ vars.TRADING_MAX_DAILY_TRADES || '10' }}
           TRADING_STOP_LOSS_PCT: ${{ vars.TRADING_STOP_LOSS_PCT || '0.05' }}

--- a/.github/workflows/trading-agent.yml
+++ b/.github/workflows/trading-agent.yml
@@ -79,7 +79,7 @@ jobs:
 
           # Configuration (from GitHub Variables)
           ALPACA_BASE_URL: ${{ vars.ALPACA_BASE_URL || 'https://paper-api.alpaca.markets' }}
-          ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6-20250620' }}
+          ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6-20250514' }}
           TRADING_MAX_POSITION_PCT: ${{ vars.TRADING_MAX_POSITION_PCT || '0.10' }}
           TRADING_MAX_DAILY_TRADES: ${{ vars.TRADING_MAX_DAILY_TRADES || '10' }}
           TRADING_STOP_LOSS_PCT: ${{ vars.TRADING_STOP_LOSS_PCT || '0.05' }}

--- a/.github/workflows/watchlist-review.yml
+++ b/.github/workflows/watchlist-review.yml
@@ -58,7 +58,7 @@ jobs:
 
           # Configuration
           ALPACA_BASE_URL: ${{ vars.ALPACA_BASE_URL || 'https://paper-api.alpaca.markets' }}
-          ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6-20250620' }}
+          ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6-20250514' }}
           TRADING_WATCHLIST: ${{ vars.TRADING_WATCHLIST || 'AAPL,MSFT,GOOGL,AMZN,NVDA,META,TSLA,JPM,V,JNJ' }}
           TRADING_CRYPTO_WATCHLIST: ${{ vars.TRADING_CRYPTO_WATCHLIST || 'BTC/USD,ETH/USD,SOL/USD' }}
           TRADING_STOCK_UNIVERSE: ${{ vars.TRADING_STOCK_UNIVERSE || '' }}

--- a/src/financial_agent/config.py
+++ b/src/financial_agent/config.py
@@ -34,7 +34,7 @@ class AIConfig(BaseSettings):
 
     api_key: str = Field(description="Anthropic API key (GitHub Secret: ANTHROPIC_API_KEY)")
     model: str = Field(
-        default="claude-sonnet-4-6-20250620",
+        default="claude-sonnet-4-6-20250514",
         description="Claude model to use (GitHub Variable: ANTHROPIC_MODEL)",
     )
     max_tokens: int = Field(


### PR DESCRIPTION
## Summary
- PR #102 changed the Claude model default to `claude-sonnet-4-6-20250620`, which doesn't exist (404 from Anthropic API)
- Every Trading Agent, Portfolio Review, and Watchlist Review run has been failing since March 17
- Fixed to the correct model ID: `claude-sonnet-4-6-20250514`

## Files changed
| File | Change |
|------|--------|
| `src/financial_agent/config.py` | Fix default model ID |
| `.github/workflows/trading-agent.yml` | Fix fallback model ID |
| `.github/workflows/portfolio-review.yml` | Fix fallback model ID |
| `.github/workflows/watchlist-review.yml` | Fix fallback model ID |

## Test plan
- [ ] CI passes (lint, tests, security)
- [ ] Next scheduled Trading Agent run completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)