### PR TITLE
Fix model ID: use claude-sonnet-4-6 (no date suffix)

### DIFF
--- a/.github/workflows/portfolio-review.yml
+++ b/.github/workflows/portfolio-review.yml
@@ -57,7 +57,7 @@ jobs:
 
           # Configuration (reuses trading variables)
           ALPACA_BASE_URL: ${{ vars.ALPACA_BASE_URL || 'https://paper-api.alpaca.markets' }}
-          ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6-20250514' }}
+          ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6' }}
           TRADING_MAX_POSITION_PCT: ${{ vars.TRADING_MAX_POSITION_PCT || '0.10' }}
           TRADING_MAX_DAILY_TRADES: ${{ vars.TRADING_MAX_DAILY_TRADES || '10' }}
           TRADING_STOP_LOSS_PCT: ${{ vars.TRADING_STOP_LOSS_PCT || '0.05' }}

--- a/.github/workflows/trading-agent.yml
+++ b/.github/workflows/trading-agent.yml
@@ -79,7 +79,7 @@ jobs:
 
           # Configuration (from GitHub Variables)
           ALPACA_BASE_URL: ${{ vars.ALPACA_BASE_URL || 'https://paper-api.alpaca.markets' }}
-          ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6-20250514' }}
+          ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6' }}
           TRADING_MAX_POSITION_PCT: ${{ vars.TRADING_MAX_POSITION_PCT || '0.10' }}
           TRADING_MAX_DAILY_TRADES: ${{ vars.TRADING_MAX_DAILY_TRADES || '10' }}
           TRADING_STOP_LOSS_PCT: ${{ vars.TRADING_STOP_LOSS_PCT || '0.05' }}

--- a/.github/workflows/watchlist-review.yml
+++ b/.github/workflows/watchlist-review.yml
@@ -58,7 +58,7 @@ jobs:
 
           # Configuration
           ALPACA_BASE_URL: ${{ vars.ALPACA_BASE_URL || 'https://paper-api.alpaca.markets' }}
-          ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6-20250514' }}
+          ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6' }}
           TRADING_WATCHLIST: ${{ vars.TRADING_WATCHLIST || 'AAPL,MSFT,GOOGL,AMZN,NVDA,META,TSLA,JPM,V,JNJ' }}
           TRADING_CRYPTO_WATCHLIST: ${{ vars.TRADING_CRYPTO_WATCHLIST || 'BTC/USD,ETH/USD,SOL/USD' }}
           TRADING_STOCK_UNIVERSE: ${{ vars.TRADING_STOCK_UNIVERSE || '' }}

--- a/src/financial_agent/config.py
+++ b/src/financial_agent/config.py
@@ -34,7 +34,7 @@ class AIConfig(BaseSettings):
 
     api_key: str = Field(description="Anthropic API key (GitHub Secret: ANTHROPIC_API_KEY)")
     model: str = Field(
-        default="claude-sonnet-4-6-20250514",
+        default="claude-sonnet-4-6",
         description="Claude model to use (GitHub Variable: ANTHROPIC_MODEL)",
     )
     max_tokens: int = Field(


### PR DESCRIPTION
## Summary
- Follow-up to #104 — the dated model ID `claude-sonnet-4-6-20250514` also returns 404
- The correct Anthropic model ID is `claude-sonnet-4-6` (no date suffix)

## Test plan
- [ ] CI passes
- [ ] Next Trading Agent run completes without 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)